### PR TITLE
Update example for public visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # CRDs-catalog
 
-For those CRDs not in https://github.com/datreeio/CRDs-catalog
+For those CRDs not in https://github.com/datreeio/CRDs-catalog.
 
 ## Usage
 
-To add a new CRD see https://github.com/datreeio/CRDs-catalog?tab=readme-ov-file#usage
+To add a new CRD see https://github.com/yannh/kubeconform?tab=readme-ov-file#customresourcedefinition-crd-support.
 
 Sample github action steps:
 
@@ -23,7 +23,7 @@ Sample github action steps:
       "-schema-location"
       "https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json"
       "-schema-location"
-      "https://git:${{ secrets.READ_ONLY_GITHUB_TOKEN }}@raw.githubusercontent.com/FundingCircle/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json"
+      "https://raw.githubusercontent.com/FundingCircle/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json"
       "-verbose"
       "-strict"
     )


### PR DESCRIPTION
Public visibility is required due to being unable to add a token in the `kubeconform` schema location URL without breaking how the URL is parsed. See https://github.com/yannh/kubeconform/pull/243.