### PR TITLE
Fix `IRSA` metadata schema

### DIFF
--- a/fundingcircle.io/irsa_v1alpha1.json
+++ b/fundingcircle.io/irsa_v1alpha1.json
@@ -13,8 +13,7 @@
           "type": "string"
         }
       },
-      "type": "object",
-      "additionalProperties": false
+      "type": "object"
     },
     "spec": {
       "properties": {


### PR DESCRIPTION
Something must have gone wrong with `openapi2jsonschema.py`.

Needed for https://github.com/FundingCircle/platform-opentelemetry/pull/63.