### PR TITLE
Fix `ElasticFileSystem` schema

### DIFF
--- a/fundingcircle.io/elasticfilesystem_v1alpha1.json
+++ b/fundingcircle.io/elasticfilesystem_v1alpha1.json
@@ -13,8 +13,7 @@
           "type": "string"
         }
       },
-      "type": "object",
-      "additionalProperties": false
+      "type": "object"
     },
     "spec": {
       "properties": {


### PR DESCRIPTION
```
'/metadata' does not validate with https://raw.githubusercontent.com/FundingCircle/CRDs-catalog/main/fundingcircle.io/elasticfilesystem_v1alpha1.json#/properties/metadata/additionalProperties: additionalProperties 'namespace' not allowed
```